### PR TITLE
Housekeeping

### DIFF
--- a/Arduino/LEDstream_WS2812B/LEDstream_WS2812B.ino
+++ b/Arduino/LEDstream_WS2812B/LEDstream_WS2812B.ino
@@ -56,15 +56,13 @@ void setup()
     indexIn       = 0,
     indexOut      = 0,
     mode          = MODE_HEADER,
-    hi, lo, chk, i, spiFlag;
+    hi, lo, chk, i;
   int16_t
     bytesBuffered = 0,
-    hold          = 0,
     c;
   int32_t
     bytesRemaining;
   unsigned long
-    startTime,
     lastByteTime,
     lastAckTime,
     t;
@@ -75,7 +73,6 @@ void setup()
 
   Serial.print("Ada\n"); // Send ACK string to host
 
-  startTime    = micros();
   lastByteTime = lastAckTime = millis();
 
   // loop() is avoided as even that small bit of function overhead
@@ -160,7 +157,6 @@ void setup()
       } 
       else {
         // End of data -- issue latch:
-        startTime  = micros();
         mode       = MODE_HEADER; // Begin next header search
         FastLED.show();
       }

--- a/Arduino/LEDstream_WS2812B/LEDstream_WS2812B.ino
+++ b/Arduino/LEDstream_WS2812B/LEDstream_WS2812B.ino
@@ -157,9 +157,6 @@ void setup()
           bytesBuffered--;
           bytesRemaining--;
         }
-        // If serial buffer is threatening to underrun, start
-        // introducing progressively longer pauses to allow more
-        // data to arrive (up to a point).
       } 
       else {
         // End of data -- issue latch:

--- a/Arduino/LEDstream_WS2812B/LEDstream_WS2812B.ino
+++ b/Arduino/LEDstream_WS2812B/LEDstream_WS2812B.ino
@@ -53,28 +53,29 @@ void setup()
   // needs to change, slowing things down tremendously.
   uint8_t
     buffer[256],
-  indexIn       = 0,
-  indexOut      = 0,
-  mode          = MODE_HEADER,
-  hi, lo, chk, i, spiFlag;
+    indexIn       = 0,
+    indexOut      = 0,
+    mode          = MODE_HEADER,
+    hi, lo, chk, i, spiFlag;
   int16_t
     bytesBuffered = 0,
-  hold          = 0,
-  c;
+    hold          = 0,
+    c;
   int32_t
     bytesRemaining;
   unsigned long
     startTime,
-  lastByteTime,
-  lastAckTime,
-  t;
-  int32_t outPos = 0;
+    lastByteTime,
+    lastAckTime,
+    t;
+  int32_t
+    outPos = 0;
 
   Serial.begin(SPEED); // Teensy/32u4 disregards baud rate; is OK!
 
   Serial.print("Ada\n"); // Send ACK string to host
 
-    startTime    = micros();
+  startTime    = micros();
   lastByteTime = lastAckTime = millis();
 
   // loop() is avoided as even that small bit of function overhead


### PR DESCRIPTION
Changes to LEDStream_WS2812B.ino:

- Cleaned up whitespace, mostly with the variable declarations
- Removed an obsolete comment about adding pauses to allow the serial stream to buffer
- Removed three obsolete variables: spiFlag, hold, and startTime.