### PR TITLE
'Serial Flush' and Housekeeping

### DIFF
--- a/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
+++ b/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
@@ -4,7 +4,6 @@
  * library (http://fastled.io) for driving led strips.
  * 
  * http://github.com/dmadison/Adalight-FastLED
- * Last Updated: 2017-05-05
  */
 
 // --- General Settings

--- a/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
+++ b/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
@@ -40,7 +40,7 @@ static const uint16_t
 
 // --- Optional Settings (uncomment to add)
 //#define CLEAR_ON_START     // LEDs are cleared on reset
-//#define SERIAL_FLUSH       // Serial buffer cleared on LED latch
+#define SERIAL_FLUSH         // Serial buffer cleared on LED latch
 //#define GROUND_PIN 10      // additional grounding pin (optional)
 //#define CALIBRATE          // sets all LEDs to the color of the first
 

--- a/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
+++ b/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
@@ -78,11 +78,8 @@ static const uint8_t magic[] = {
 #define LOCHECK    (MAGICSIZE + 1)
 #define CHECKSUM   (MAGICSIZE + 2)
 
-#define MODE_HEADER 0
-#define MODE_DATA   1
+enum processModes_t {Header, Data} mode = Header;
 
-static uint8_t
-	mode = MODE_HEADER;
 static int16_t
 	c;
 static uint16_t
@@ -150,10 +147,10 @@ void adalight(){
 		lastByteTime = lastAckTime = t; // Reset timeout counters
 
 		switch(mode) {
-			case MODE_HEADER:
+			case Header:
 				headerMode();
 				break;
-			case MODE_DATA:
+			case Data:
 				dataMode();
 				break;
 		}
@@ -194,7 +191,7 @@ void headerMode(){
 					bytesRemaining = 3L * (256L * (long)hi + (long)lo + 1L);
 					outPos = 0;
 					memset(leds, 0, Num_Leds * sizeof(struct CRGB));
-					mode = MODE_DATA; // Proceed to latch wait mode
+					mode = Data; // Proceed to latch wait mode
 				}
 				headPos = 0; // Reset header position regardless of checksum result
 				break;
@@ -211,7 +208,7 @@ void dataMode(){
  
 	if(bytesRemaining == 0) {
 		// End of data -- issue latch:
-		mode = MODE_HEADER; // Begin next header search
+		mode = Header; // Begin next header search
 		FastLED.show();
 		D_FPS;
 		D_LED(OFF);

--- a/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
+++ b/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
@@ -34,7 +34,7 @@ static const uint8_t
 
 // --- Serial Settings
 static const unsigned long
-	SerialSpeed    = 115200; // serial port speed, max available
+	SerialSpeed    = 115200; // serial port speed
 static const uint16_t
 	SerialTimeout  = 150;    // time before LEDs are shut off if no data (in seconds)
 

--- a/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
+++ b/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
@@ -4,6 +4,21 @@
  * library (http://fastled.io) for driving led strips.
  * 
  * http://github.com/dmadison/Adalight-FastLED
+ *
+ * --------------------------------------------------------------------
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * --------------------------------------------------------------------
  */
 
 // --- General Settings

--- a/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
+++ b/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
@@ -1,6 +1,6 @@
 /* LEDstream_FastLED
  * 
- * Modified version of Adalight protocol that uses the FastLED
+ * Modified version of Adalight that uses the FastLED
  * library (http://fastled.io) for driving led strips.
  * 
  * http://github.com/dmadison/Adalight-FastLED

--- a/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
+++ b/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
@@ -242,6 +242,7 @@ void timeouts(){
 		if((t - lastByteTime) > SerialTimeout * 1000) {
 			memset(leds, 0, Num_Leds * sizeof(struct CRGB)); //filling Led array by zeroes
 			FastLED.show();
+			mode = Header;
 			lastByteTime = t; // Reset counter
 		}
 	}

--- a/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
+++ b/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
@@ -39,8 +39,8 @@ static const uint16_t
 	SerialTimeout  = 150;    // time before LEDs are shut off if no data (in seconds)
 
 // --- Optional Settings (uncomment to add)
-//#define CLEAR_ON_START     // LEDs are cleared on reset
 #define SERIAL_FLUSH         // Serial buffer cleared on LED latch
+//#define CLEAR_ON_START     // LEDs are cleared on reset
 //#define GROUND_PIN 10      // additional grounding pin (optional)
 //#define CALIBRATE          // sets all LEDs to the color of the first
 

--- a/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
+++ b/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
@@ -7,8 +7,9 @@
  */
 
 // --- General Settings
-static const uint8_t 
-	Num_Leds   =  80,        // strip length
+static const uint16_t 
+	Num_Leds   =  80;        // strip length
+static const uint8_t
 	Led_Pin    =  6,         // Arduino data output pin
 	Brightness =  255;       // maximum brightness
 

--- a/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
+++ b/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
@@ -40,6 +40,7 @@ static const uint16_t
 
 // --- Optional Settings (uncomment to add)
 //#define CLEAR_ON_START     // LEDs are cleared on reset
+//#define SERIAL_FLUSH       // Serial buffer cleared on LED latch
 //#define GROUND_PIN 10      // additional grounding pin (optional)
 //#define CALIBRATE          // sets all LEDs to the color of the first
 
@@ -214,6 +215,9 @@ void dataMode(){
 		FastLED.show();
 		D_FPS;
 		D_LED(OFF);
+		#ifdef SERIAL_FLUSH
+			serialFlush();
+		#endif
 	}
 }
 
@@ -243,5 +247,11 @@ void timeouts(){
 			FastLED.show();
 			lastByteTime = t; // Reset counter
 		}
+	}
+}
+
+void serialFlush(){
+	while(Serial.available() > 0) {
+		byte r = Serial.read();
 	}
 }

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ In addition to ambilight setups, the protocol can be used to stream *any* color 
 
 For this sketch to work, you'll need to have a copy of the FastLED library. You can download FastLED [from GitHub](https://github.com/FastLED/FastLED) or through the libraries manager of the Arduino IDE. This program was writen using FastLED 3.1.3 - note that earlier versions of FastLED are untested and may not work properly.
 
+For more information on my own ambilight setup, see [the project page](http://www.partsnotincluded.com/projects/ambilight/) on [PartsNotIncluded.com](http://www.partsnotincluded.com/).
+
 ## Basic Setup
 
 Open the LEDstream_FastLED file in the Arduino IDE and customize the settings at the top for your setup. You will need to change:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In addition to ambilight setups, the protocol can be used to stream *any* color 
 
 For this sketch to work, you'll need to have a copy of the FastLED library. You can download FastLED [from GitHub](https://github.com/FastLED/FastLED) or through the libraries manager of the Arduino IDE. This program was writen using FastLED 3.1.3 - note that earlier versions of FastLED are untested and may not work properly.
 
-## Configuration
+## Basic Setup
 
 Open the LEDstream_FastLED file in the Arduino IDE and customize the settings at the top for your setup. You will need to change:
 
@@ -18,16 +18,18 @@ Open the LEDstream_FastLED file in the Arduino IDE and customize the settings at
 - LED data pin
 - LED type
 
-Additional settings allow for adjusting:
+Upload to your Arduino and use a corresponding PC application to stream color data. You can get the Processing files from the [main Adalight repository](https://github.com/adafruit/Adalight), though I would recommend using [Patrick Siegler's](https://github.com/psieg/) fork of Lightpacks's Prismatik, which you can find [here](https://github.com/psieg/Lightpack/releases).
+
+## Additional Settings
+
+There are additional settings to allow for adjusting:
 
 - Max brightness
 - LED color order
 - Serial speed
 - Serial timeout length
 
-There are also optional settings to clear the LEDs on reset, configure a dedicated ground pin, and to put the Arduino into a "calibration" mode, where all LED colors match the first LED.
-
-Upload to your Arduino and use a corresponding PC application to stream color data. You can get the Processing files from the [main Adalight repository](https://github.com/adafruit/Adalight), though I would recommend using [Patrick Siegler's](https://github.com/psieg/) fork of Lightpacks's Prismatik, which you can find [here](https://github.com/psieg/Lightpack/releases).
+There are also optional settings to clear the LEDs on reset, configure a dedicated ground pin, and to put the Arduino into a "calibration" mode, where all LED colors match the first LED. To help with flickering, the option to flush the serial buffer after every latch is enabled by default.
 
 ## Debug Settings
 


### PR DESCRIPTION
New Features:
- Added a 'serial flush' option, enabled by default. This clears the incoming serial buffer after each latched frame, and fixes flickering at high data rates.

Changes:
- Increased LED limit from 255 to 21,845.

Behind the scenes:
- Reworked mode setting to use enumeration.
- Added LPGL license text to source code.
- 'Updated' date removed from source code. Keep track of update times with git, instead.

Will merge with master after testing.