### PR TITLE
Updated Timeouts

### DIFF
--- a/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
+++ b/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
@@ -36,7 +36,7 @@ static const uint8_t
 static const unsigned long
 	SerialSpeed    = 115200; // serial port speed
 static const uint16_t
-	SerialTimeout  = 150;    // time before LEDs are shut off if no data (in seconds), 0 to disable
+	SerialTimeout  = 60;     // time before LEDs are shut off if no data (in seconds), 0 to disable
 
 // --- Optional Settings (uncomment to add)
 #define SERIAL_FLUSH         // Serial buffer cleared on LED latch

--- a/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
+++ b/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
@@ -234,12 +234,12 @@ void dataSet(){
 void timeouts(){
 	// No data received. If this persists, send an ACK packet
 	// to host once every second to alert it to our presence.
-	if((t - lastAckTime) > 1000) {
+	if((t - lastAckTime) >= 1000) {
 		Serial.print("Ada\n"); // Send ACK string to host
 		lastAckTime = t; // Reset counter
 
 		// If no data received for an extended time, turn off all LEDs.
-		if((t - lastByteTime) > SerialTimeout * 1000) {
+		if((t - lastByteTime) >= SerialTimeout * 1000) {
 			memset(leds, 0, Num_Leds * sizeof(struct CRGB)); //filling Led array by zeroes
 			FastLED.show();
 			mode = Header;

--- a/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
+++ b/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
@@ -239,7 +239,7 @@ void timeouts(){
 		lastAckTime = t; // Reset counter
 
 		// If no data received for an extended time, turn off all LEDs.
-		if((t - lastByteTime) >= SerialTimeout * 1000) {
+		if((t - lastByteTime) >= (uint32_t) SerialTimeout * 1000) {
 			memset(leds, 0, Num_Leds * sizeof(struct CRGB)); //filling Led array by zeroes
 			FastLED.show();
 			mode = Header;

--- a/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
+++ b/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
@@ -36,7 +36,7 @@ static const uint8_t
 static const unsigned long
 	SerialSpeed    = 115200; // serial port speed
 static const uint16_t
-	SerialTimeout  = 150;    // time before LEDs are shut off if no data (in seconds)
+	SerialTimeout  = 150;    // time before LEDs are shut off if no data (in seconds), 0 to disable
 
 // --- Optional Settings (uncomment to add)
 #define SERIAL_FLUSH         // Serial buffer cleared on LED latch
@@ -239,7 +239,7 @@ void timeouts(){
 		lastAckTime = t; // Reset counter
 
 		// If no data received for an extended time, turn off all LEDs.
-		if((t - lastByteTime) >= (uint32_t) SerialTimeout * 1000) {
+		if(SerialTimeout != 0 && (t - lastByteTime) >= (uint32_t) SerialTimeout * 1000) {
 			memset(leds, 0, Num_Leds * sizeof(struct CRGB)); //filling Led array by zeroes
 			FastLED.show();
 			mode = Header;


### PR DESCRIPTION
Bugfix update to fix the overflow on the serial timeout check. Serial timeout should now work with values up to ~18 hours.

I also decreased the default timeout period to 1 minute (from 2:30) and added the ability to turn the timeout off entirely (setting of '0'). Timeouts are now also evaluated at 1000 milliseconds exactly rather than 1001, which makes no practical difference but makes more logical sense.