### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ env:
     - IDE_VERSION=1.8.1
 matrix:
   include:
-    - name: "Arduino Uno - WS2812B"
-      env: BOARD=arduino:avr:uno
+    - name: "WS2812B"
 
 before_install:
   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_1.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :1 -ac -screen 0 1280x1024x16"
@@ -22,7 +21,7 @@ before_install:
   - arduino --install-library "FastLED:3.2.0"
 
   # Sketch Compiling Functions
-  - CYAN="\033[36m"; NOC="\033[0m";
+  - CYAN="\033[36m"; YELLOW="\033[33m"; NOC="\033[0m";
   - buildSketchPath() {
       echo -e "\n${CYAN}Building sketch ${1##*/}${NOC}";
       arduino --verify --board $BOARD "$1";
@@ -33,9 +32,17 @@ before_install:
         buildSketchPath $f;
       done;
     }
+  - buildBoard() {
+      export BOARD="$1";
+      echo -e "\n${YELLOW}Now using board $BOARD${NOC}";
+      buildAllSketches;
+    }
 
 script:
-  - buildAllSketches
+  - buildBoard "arduino:avr:uno"
+  - buildBoard "arduino:avr:nano:cpu=atmega328"
+  - buildBoard "arduino:avr:leonardo"
+  - buildBoard "arduino:avr:mega:cpu=atmega2560"
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+language: C
+env:
+  global:
+    - IDE_VERSION=1.8.1
+matrix:
+  include:
+    - name: "Arduino Uno - WS2812B"
+      env: BOARD=arduino:avr:uno
+
+before_install:
+  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_1.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :1 -ac -screen 0 1280x1024x16"
+  - sleep 3
+  - export DISPLAY=:1.0
+
+  # Install Arduino IDE
+  - wget http://downloads.arduino.cc/arduino-$IDE_VERSION-linux64.tar.xz
+  - tar xf arduino-$IDE_VERSION-linux64.tar.xz
+  - sudo mv arduino-$IDE_VERSION /usr/local/share/arduino
+  - sudo ln -s /usr/local/share/arduino/arduino /usr/local/bin/arduino
+  
+  # Install Libraries
+  - arduino --install-library "FastLED:3.2.0"
+
+  # Sketch Compiling Functions
+  - CYAN="\033[36m"; NOC="\033[0m";
+  - buildSketchPath() {
+      echo -e "\n${CYAN}Building sketch ${1##*/}${NOC}";
+      arduino --verify --board $BOARD "$1";
+    }
+  - buildAllSketches() {
+      for f in $(find $PWD -name '*.ino');
+      do
+        buildSketchPath $f;
+      done;
+    }
+
+script:
+  - buildAllSketches
+
+notifications:
+  email:
+    on_success: change
+    on_failure: change

--- a/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
+++ b/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
@@ -250,6 +250,6 @@ void timeouts(){
 
 void serialFlush(){
 	while(Serial.available() > 0) {
-		byte r = Serial.read();
+		Serial.read();
 	}
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Adalight-FastLED
+# Adalight-FastLED [![Build Status](https://travis-ci.org/dmadison/Adalight-FastLED.svg?branch=master)](https://travis-ci.org/dmadison/Adalight-FastLED)
 
 ![Adalight-Rainbow](http://i.imgur.com/sHygxq9.jpg)
 


### PR DESCRIPTION
Adds cursory Travis CI support. For each commit, this builds the sketch for a few default Arduino boards and checks if it compiles. I'd also like to update this to check the sketch with a few different LED types, but that's a few commits away.

This PR also fixes the warning for the unused variable in the serial flush function.