### PR TITLE
Clock Pin Support (4-Wire LEDs)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ env:
 matrix:
   include:
     - name: "WS2812B"
+      env: BUILD_FLAGS="-DDEBUG_CI -DLED_CHIPSET=WS2812B"
+    - name: "APA102"
+      env: BUILD_FLAGS="-DDEBUG_CI -DLED_CHIPSET=APA102 -DPIN_CLOCK=7"
 
 before_install:
   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_1.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :1 -ac -screen 0 1280x1024x16"
@@ -24,7 +27,7 @@ before_install:
   - CYAN="\033[36m"; YELLOW="\033[33m"; NOC="\033[0m";
   - buildSketchPath() {
       echo -e "\n${CYAN}Building sketch ${1##*/}${NOC}";
-      arduino --verify --board $BOARD "$1";
+      arduino --verify --board $BOARD --pref build.extra_flags="$BUILD_FLAGS" "$1";
     }
   - buildAllSketches() {
       for f in $(find $PWD -name '*.ino');

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ env:
 matrix:
   include:
     - name: "WS2812B"
-      env: BUILD_FLAGS="-DDEBUG_CI -DLED_CHIPSET=WS2812B"
-    - name: "APA102"
-      env: BUILD_FLAGS="-DDEBUG_CI -DLED_CHIPSET=APA102 -DPIN_CLOCK=7"
 
 before_install:
   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_1.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :1 -ac -screen 0 1280x1024x16"
@@ -27,7 +24,7 @@ before_install:
   - CYAN="\033[36m"; YELLOW="\033[33m"; NOC="\033[0m";
   - buildSketchPath() {
       echo -e "\n${CYAN}Building sketch ${1##*/}${NOC}";
-      arduino --verify --board $BOARD --pref build.extra_flags="$BUILD_FLAGS" "$1";
+      arduino --verify --board $BOARD "$1";
     }
   - buildAllSketches() {
       for f in $(find $PWD -name '*.ino');

--- a/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
+++ b/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
@@ -93,6 +93,11 @@ static unsigned long
 	lastAckTime;
 
 // Debug macros initialized
+#ifdef DEBUG_CI
+#undef LED_TYPE
+#define LED_TYPE LED_CHIPSET  // Use command line chipset definition
+#endif
+
 #ifdef DEBUG_LED
 	#define ON  1
 	#define OFF 0

--- a/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
+++ b/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
@@ -25,12 +25,12 @@
 static const uint16_t 
 	Num_Leds   =  80;        // strip length
 static const uint8_t
-	Led_Pin    =  6,         // Arduino data output pin
 	Brightness =  255;       // maximum brightness
 
 // --- FastLED Setings
 #define LED_TYPE     WS2812B // led strip type for FastLED
 #define COLOR_ORDER  GRB     // color order for bitbang
+#define PIN_DATA     6       // led data output pin
 
 // --- Serial Settings
 static const unsigned long
@@ -122,7 +122,7 @@ void setup(){
 		pinMode(DEBUG_FPS, OUTPUT);
 	#endif
 
-	FastLED.addLeds<LED_TYPE, Led_Pin, COLOR_ORDER>(leds, Num_Leds);
+	FastLED.addLeds<LED_TYPE, PIN_DATA, COLOR_ORDER>(leds, Num_Leds);
 	FastLED.setBrightness(Brightness);
 
 	#ifdef CLEAR_ON_START

--- a/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
+++ b/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
@@ -31,6 +31,7 @@ static const uint8_t
 #define LED_TYPE     WS2812B // led strip type for FastLED
 #define COLOR_ORDER  GRB     // color order for bitbang
 #define PIN_DATA     6       // led data output pin
+//#define PIN_CLOCK  7       // led data clock pin (uncomment if you're using a 4-wire LED type)
 
 // --- Serial Settings
 static const unsigned long
@@ -122,7 +123,12 @@ void setup(){
 		pinMode(DEBUG_FPS, OUTPUT);
 	#endif
 
-	FastLED.addLeds<LED_TYPE, PIN_DATA, COLOR_ORDER>(leds, Num_Leds);
+	#ifdef PIN_CLOCK
+		FastLED.addLeds<LED_TYPE, PIN_DATA, PIN_CLOCK, COLOR_ORDER>(leds, Num_Leds);
+	#else
+		FastLED.addLeds<LED_TYPE, PIN_DATA, COLOR_ORDER>(leds, Num_Leds);
+	#endif
+	
 	FastLED.setBrightness(Brightness);
 
 	#ifdef CLEAR_ON_START

--- a/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
+++ b/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
@@ -93,11 +93,6 @@ static unsigned long
 	lastAckTime;
 
 // Debug macros initialized
-#ifdef DEBUG_CI
-#undef LED_TYPE
-#define LED_TYPE LED_CHIPSET  // Use command line chipset definition
-#endif
-
 #ifdef DEBUG_LED
 	#define ON  1
 	#define OFF 0

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Open the LEDstream_FastLED file in the Arduino IDE and customize the settings at
 - LED data pin
 - LED type
 
+If you are using a 4-wire LED chipset like APA102, you will need to uncomment the `PIN_CLOCK` line and set that as well.
+
 Upload to your Arduino and use a corresponding PC application to stream color data. You can get the Processing files from the [main Adalight repository](https://github.com/adafruit/Adalight), though I would recommend using [Patrick Siegler's](https://github.com/psieg/) fork of Lightpacks's Prismatik, which you can find [here](https://github.com/psieg/Lightpack/releases).
 
 ## Additional Settings


### PR DESCRIPTION
Adds support for 4-wire LED chipsets. Previously this required the user to edit the `addLeds` line themselves to add the clock pin. Now it just requires uncommenting the `PIN_CLOCK` line and specifying the clock pin they're using.

I also tried to add the APA102 chipset to continuous integration using the `extra_flags` option, but apparently some of the USB information is passed to the Leonardo this way which breaks compilation. Holding off on that until I can figure out a better solution.