### PR TITLE
Attempt Number 2 - "Enhancements!"

### DIFF
--- a/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
+++ b/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
@@ -27,7 +27,7 @@ const uint16_t
 uint8_t
   Brightness =  255;        // variable brightness
 const uint8_t
-  Max_Brightness =  60;        // maximum brightness
+  Max_Brightness =  255;        // maximum brightness
 
 // --- FastLED Setings
 #define LED_TYPE     WS2812B  // led strip type for FastLED

--- a/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
+++ b/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
@@ -45,6 +45,7 @@ const uint16_t
 // --- Optional Settings (uncomment to add)
 #define SERIAL_FLUSH          // Serial buffer cleared on LED latch
 // #define CLEAR_ON_START     // LEDs are cleared on reset
+// #define STORE_BRIGHTNESS   // Store brightness in EEPROM if set by the user
 
 // --- Debug Settings (uncomment to add)
 // #define DEBUG_LED 13       // toggles the Arduino's built-in LED on header match
@@ -133,7 +134,8 @@ void timeouts();
 #endif
 
 void setup(){
-  // Check if we've stored brightness to EEPROM, save it if not.
+  // Check if we've stored brightness to EEPROM (if enabled), save it if not.
+  #ifdef STORE_BRIGHTNESS
   int brightSet = EEPROM.read(0);
   if (brightSet != 1) {
     EEPROM.write(0,1);
@@ -141,6 +143,7 @@ void setup(){
   } else {
     Brightness = EEPROM.read(1);
   }
+  #endif
 	#ifdef DEBUG_LED
 		pinMode(DEBUG_LED, OUTPUT);
 		digitalWrite(DEBUG_LED, LOW);
@@ -242,7 +245,9 @@ void headerMode(){
           if (hi == br_str[0] && lo == br_str[1]) {
             if (chk <= Max_Brightness && chk >= 0) {
               Brightness = chk;
-              EEPROM.write(1,Brightness);
+              #ifdef STORE_BRIGHTNESS
+                EEPROM.write(1,Brightness);
+              #endif
               FastLED.setBrightness(Brightness);
               FastLED.show();
               lastByteTime = lastAckTime = millis(); // Set initial counters

--- a/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
+++ b/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
@@ -46,7 +46,7 @@ const uint16_t
 // --- Debug Settings (uncomment to add)
 // #define DEBUG_LED 13       // toggles the Arduino's built-in LED on header match
 // #define DEBUG_FPS 8        // enables a pulse on LED latch
-
+// #define ECHO_LEDCOUNT      // Echo LED count in ack message for auto-setup
 // --------------------------------------------------------------------
 
 #include <FastLED.h>
@@ -222,7 +222,11 @@ void timeouts(){
 	// No data received. If this persists, send an ACK packet
 	// to host once every second to alert it to our presence.
 	if((t - lastAckTime) >= 1000) {
-		Serial.print("Ada\n"); // Send ACK string to host
+    #ifdef ECHO_LEDCOUNT
+		  Serial.print("Ada\n" + Num_Leds); // Send ACK string to host with LED count
+    #else
+      Serial.print("Ada\n"); // Send ACK string to host
+    #endif
 		lastAckTime = t; // Reset counter
 
 		// If no data received for an extended time, turn off all LEDs.

--- a/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
+++ b/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
@@ -20,6 +20,7 @@
  */
 
 #include <Arduino.h>
+#include <EEPROM.h>
 
 // --- General Settings
 const uint16_t 
@@ -115,6 +116,14 @@ void timeouts();
 #endif
 
 void setup(){
+  // Check if we've stored brightness to EEPROM, save it if not.
+  int brightSet = EEPROM.read(0);
+  if (brightSet != 1) {
+    EEPROM.write(0,1);
+    EEPROM.write(1,Brightness);
+  } else {
+    Brightness = EEPROM.read(1);
+  }
 	#ifdef DEBUG_LED
 		pinMode(DEBUG_LED, OUTPUT);
 		digitalWrite(DEBUG_LED, LOW);
@@ -214,6 +223,7 @@ void headerMode(){
           if (hi == 4 && lo == 20 && chk != Brightness) {
             if (chk <= Max_Brightness && chk >= 0) {
               Brightness = chk;
+              EEPROM.write(1,Brightness);
               FastLED.setBrightness(Brightness);
               FastLED.show();
             }            

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ There are additional settings to allow for adjusting:
 - LED color order
 - Serial speed
 - Serial timeout length
+- Store brightness to EEPROM
 
 There are also optional settings to clear the LEDs on reset or flush the incoming serial buffer after every latch. This latter option is enabled by default to help with flickering when using WS2812B LEDs.
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,22 @@ There are additional settings to allow for adjusting:
 - LED color order
 - Serial speed
 - Serial timeout length
+- Echo Brightness on Acknowledgment
+- Echo LedCount on Acknowledgement
 
 There are also optional settings to clear the LEDs on reset or flush the incoming serial buffer after every latch. This latter option is enabled by default to help with flickering when using WS2812B LEDs.
+
+## Set Brightness
+
+You can *also* now set the brightness of the LEDs after boot, without having to modify config files. To do so, send a serial packet to the device,
+but use the following byte sequence:
+
+Bytes 0-2 (Magic) ('ADA'), etc.
+Byte 3 (hi) - 04
+Byte 4 (lo) - 20
+Byte 5 (brightness) - 0-255
+
+You should ensure that you are not trying to send color data at the same time, or issues will arise.
 
 ## Debug Settings
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ There are additional settings to allow for adjusting:
 - LED color order
 - Serial speed
 - Serial timeout length
-- Echo Brightness on Acknowledgment
-- Echo LedCount on Acknowledgement
 
 There are also optional settings to clear the LEDs on reset or flush the incoming serial buffer after every latch. This latter option is enabled by default to help with flickering when using WS2812B LEDs.
 
@@ -43,12 +41,35 @@ There are also optional settings to clear the LEDs on reset or flush the incomin
 You can *also* now set the brightness of the LEDs after boot, without having to modify config files. To do so, send a serial packet to the device,
 but use the following byte sequence:
 
-Bytes 0-2 (Magic) ('ADA'), etc.
-Byte 3 (hi) - 04
-Byte 4 (lo) - 20
+Bytes 0-2 (Command Magic) ('Adb'), etc.
+Byte 3 (hi) - "B"
+Byte 4 (lo) - "R"
 Byte 5 (brightness) - 0-255
 
 You should ensure that you are not trying to send color data at the same time, or issues will arise.
+
+## Fetch State
+
+Similar to setting brightness, you can query the device state by sending the following command::
+
+Bytes 0-2 (Command Magic) ('Adb'), etc.
+Byte 3 (hi) - "S"
+Byte 4 (lo) - "T"
+Byte 5 (unused) - 0
+
+This will cause the device to return a state message, formatted like so:
+
+AdbN=<led_count>;B=<brightness>
+
+Or as an example:
+
+AdbN=80;B=160
+
+The first three characters will always be the "Command Magic" value of "Adb", or whatever value is defined in the sketch.
+Next will be N= and then the defined LED count.
+Next is a ";" as a separator, and finally "B=", and the current user-defined brightness.
+
+
 
 ## Debug Settings
 


### PR DESCRIPTION
Not trying to be pesky, but I did revisit the ideas I had, only taking into account your feedback from the past PR.

This implements the same features as the previous request - set brightness, get device state (led count, brightness), but now does so via a secondary user-defined magic word. 

Header mode does mostly the same thing, only now it checks against both magic words, and then sets an "isMagic" or "isCmd" boolean.

Once we get to the part where the checksum is calculated, I just check to see if "isMagic" or "isCmd" is set. 

If isMagic is set, we reset the pos count, put the device in "data mode", and set both "mode" booleans back to false.

If isCmd is set, we then look at the hi and lo bytes, and compare them to some more preset commands ("ST" and "BR"). If either of these is set, then either the brightness will be set, or the state will be echoed back to the user.

If you don't want to merge this, no big deal...I can fork and make my own. But, given the amount of stuff I've already got in the wild, it'd be nice to just have this in someone else's hands...