### PR TITLE
LED Indices / Groups

### DIFF
--- a/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
+++ b/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
@@ -87,6 +87,7 @@ unsigned long lastByteTime;  // ms timestamp, last byte received
 unsigned long lastAckTime;   // ms timestamp, lask acknowledge to the host
 
 unsigned long (*const now)(void) = millis;  // timing function
+const unsigned long Timebase     = 1000;    // time units per second
 
 void headerMode();
 void dataMode();
@@ -225,12 +226,12 @@ void timeouts(){
 
 	// No data received. If this persists, send an ACK packet
 	// to host once every second to alert it to our presence.
-	if((t - lastAckTime) >= 1000) {
+	if((t - lastAckTime) >= Timebase) {
 		Serial.print("Ada\n"); // Send ACK string to host
 		lastAckTime = t; // Reset counter
 
 		// If no data received for an extended time, turn off all LEDs.
-		if(SerialTimeout != 0 && (t - lastByteTime) >= (uint32_t) SerialTimeout * 1000) {
+		if(SerialTimeout != 0 && (t - lastByteTime) >= (uint32_t) SerialTimeout * Timebase) {
 			memset(leds, 0, Num_Leds * sizeof(struct CRGB)); //filling Led array by zeroes
 			FastLED.show();
 			mode = Header;

--- a/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
+++ b/Arduino/LEDstream_FastLED/LEDstream_FastLED.ino
@@ -102,9 +102,6 @@ void timeouts();
 #endif
 
 #ifdef DEBUG_LED
-	#define ON  1
-	#define OFF 0
-
 	#define D_LED(x) do {digitalWrite(DEBUG_LED, x);} while(0)
 #else
 	#define D_LED(x)
@@ -192,7 +189,7 @@ void headerMode(){
 				if(chk == (hi ^ lo ^ 0x55)) {
 					// Checksum looks valid. Get 16-bit LED count, add 1
 					// (# LEDs is always > 0) and multiply by 3 for R,G,B.
-					D_LED(ON);
+					D_LED(HIGH);
 					bytesRemaining = 3L * (256L * (long)hi + (long)lo + 1L);
 					outPos = 0;
 					memset(leds, 0, Num_Leds * sizeof(struct CRGB));
@@ -216,7 +213,7 @@ void dataMode(){
 		mode = Header; // Begin next header search
 		FastLED.show();
 		D_FPS;
-		D_LED(OFF);
+		D_LED(LOW);
 		SERIAL_FLUSH;
 	}
 }


### PR DESCRIPTION
This PR rewrites the code to use LED indices and channels rather than the raw pointer. That should solve any strange issues caused by violating strict aliasing (i.e. accessing the LED data via memory pointer rather than via the struct members).

I've also added a "grouping" feature, which will distribute LED data if the received amount is a factor of the number of LEDs in the strip. For example, if there are 80 LEDs in the strip and data for 40 LEDs is received, the data will be copied so that the entire strip is lit, with each virtual LED mapped to groups of 2 physical LEDs. Receiving 20 LEDs will map to groups of 4, 10 LEDs to groups of 8, 5 LEDs to groups of 16, etc. etc.

For setups with a lot of LEDs this allows you to send less data to the device, increasing throughput and therefore framerate at the expense of resolution. This is disabled by default, and can be enabled by uncommenting the relevant define.

This also includes a few minor changes to clean up the code a bit: removing a few global variables, some redundant macros, and more flexible timekeeping definitions.

